### PR TITLE
feat: resolve config path with local, host-root, and global precedence

### DIFF
--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -16,7 +16,12 @@ from jinja2 import Template
 from pydantic import BaseModel, Field, ValidationError
 
 from ralph_loop.backends import get_backend
-from ralph_loop.config import RalphConfig, VisualVerifyConfig
+from ralph_loop.config import (
+    ConfigNotFoundError,
+    RalphConfig,
+    VisualVerifyConfig,
+    resolve_config_path,
+)
 from ralph_loop.loop import run_loop
 from ralph_loop.progress import (
     FeedbackEntry,
@@ -37,10 +42,14 @@ from ralph_loop.verification.visual import run_visual_verification
 
 
 def _default_config_path() -> str:
-    configured = os.environ.get("RALPH_CONFIG")
-    if configured:
-        return configured
-    return str((Path.home() / ".config" / "ralph-loop" / "config.yaml").resolve())
+    """Resolve config path using the precedence chain.
+
+    Called by Click as the default for ``--config`` when no explicit value is given.
+    """
+    try:
+        return resolve_config_path()
+    except ConfigNotFoundError as exc:
+        raise click.UsageError(str(exc)) from exc
 
 
 def _load_config(config_path: str, loop_dir: str = ".") -> RalphConfig:

--- a/ralph_loop/config.py
+++ b/ralph_loop/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -7,6 +9,92 @@ from pydantic import BaseModel, Field, field_validator
 
 
 PROJECT_INSTRUCTIONS_FILENAMES: tuple[str, ...] = ("AGENTS.md", "CLAUDE.md", "COPILOT.md")
+LOCAL_CONFIG_FILENAME: str = "ralph-config.yaml"
+GLOBAL_CONFIG_PATH: Path = Path("~/.config/ralph-loop/config.yaml")
+
+
+def _get_repo_root() -> Path | None:
+    """Return the host repo root, preferring the superproject when inside a submodule.
+
+    Returns ``None`` if *git* is unavailable or CWD is not inside a git repository.
+    """
+    try:
+        # If we are a submodule, this returns the host (superproject) root.
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-superproject-working-tree"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        superproject = result.stdout.strip() if result.returncode == 0 else ""
+        if superproject:
+            return Path(superproject).resolve()
+
+        # Not a submodule — fall back to the repo root.
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip()).resolve()
+    except FileNotFoundError:
+        # git is not installed.
+        pass
+    return None
+
+
+class ConfigNotFoundError(FileNotFoundError):
+    """Raised when no configuration file can be found in any searched location."""
+
+    def __init__(self, attempted: list[str]) -> None:
+        paths_list = "\n  - ".join(attempted)
+        super().__init__(f"No ralph-loop config file found. Searched (in order):\n  - {paths_list}")
+        self.attempted = attempted
+
+
+def resolve_config_path() -> str:
+    """Resolve the config file path using the precedence chain.
+
+    Precedence (highest to lowest):
+      1. ``RALPH_CONFIG`` environment variable.
+      2. ``ralph-config.yaml`` in the current working directory.
+      3. ``ralph-config.yaml`` at the host/repo root (submodule-aware).
+      4. ``~/.config/ralph-loop/config.yaml`` (global fallback).
+
+    Raises:
+        ConfigNotFoundError: when no config file is found.
+    """
+    attempted: list[str] = []
+
+    # 1. RALPH_CONFIG env var
+    env_path = os.environ.get("RALPH_CONFIG")
+    if env_path:
+        return env_path  # trust the user; existence checked by RalphConfig.load
+
+    # 2. Local ralph-config.yaml in CWD
+    cwd = Path.cwd().resolve()
+    local_candidate = cwd / LOCAL_CONFIG_FILENAME
+    attempted.append(str(local_candidate))
+    if local_candidate.is_file():
+        return str(local_candidate)
+
+    # 3. Host repo root ralph-config.yaml
+    repo_root = _get_repo_root()
+    if repo_root and repo_root != cwd:
+        repo_candidate = repo_root / LOCAL_CONFIG_FILENAME
+        attempted.append(str(repo_candidate))
+        if repo_candidate.is_file():
+            return str(repo_candidate)
+
+    # 4. Global config
+    global_candidate = GLOBAL_CONFIG_PATH.expanduser().resolve()
+    attempted.append(str(global_candidate))
+    if global_candidate.is_file():
+        return str(global_candidate)
+
+    raise ConfigNotFoundError(attempted)
 
 
 class BackendConfig(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -873,3 +873,35 @@ def test_run_command_returns_loop_exit_code(sample_workspace: Path, monkeypatch)
     result = runner.invoke(main, ["run", "--config", str(config_path), "--sandbox", "none"])
 
     assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Config resolution via CLI (no --config flag)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_uses_local_config_when_no_flag(sample_workspace: Path, monkeypatch) -> None:
+    """CLI picks up ralph-config.yaml from CWD when --config is omitted."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+    monkeypatch.chdir(sample_workspace)
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "ralph-loop status" in result.output
+
+
+def test_cli_error_when_no_config_found(tmp_path: Path, monkeypatch) -> None:
+    """CLI shows clear error with attempted paths when no config exists."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
+
+    fake_global = tmp_path / "nope" / "config.yaml"
+    monkeypatch.setattr("ralph_loop.config.GLOBAL_CONFIG_PATH", Path(str(fake_global)))
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code != 0
+    assert "No ralph-loop config file found" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from ralph_loop.config import AuthConfig, RalphConfig
+from ralph_loop.config import AuthConfig, ConfigNotFoundError, RalphConfig, resolve_config_path
 
 
 def test_load_config(sample_workspace: Path) -> None:
@@ -80,3 +80,147 @@ def test_load_discovers_project_instructions_from_loop_ancestors(tmp_path: Path)
     config = RalphConfig.load(str(config_path), loop_dir=str(loop_dir))
 
     assert config.project_instructions == str(instructions.resolve())
+
+
+# ---------------------------------------------------------------------------
+# resolve_config_path tests
+# ---------------------------------------------------------------------------
+
+_MINIMAL_CONFIG = yaml.safe_dump({"backends": {"coder": {"engine": "codex"}}})
+
+
+def test_resolve_explicit_config_flag(sample_workspace: Path) -> None:
+    """Scenario 1: --config is passed — handled by Click, not resolve_config_path.
+
+    This test verifies that RalphConfig.load still works with an explicit path.
+    """
+    config = RalphConfig.load(str(sample_workspace / "ralph-config.yaml"))
+    assert config.get_backend("coder").engine == "codex"
+
+
+def test_resolve_ralph_config_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scenario 2: RALPH_CONFIG env var takes precedence."""
+    env_config = tmp_path / "env-config.yaml"
+    env_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    monkeypatch.setenv("RALPH_CONFIG", str(env_config))
+    monkeypatch.chdir(tmp_path / "nonexistent_cwd" if False else tmp_path)
+
+    result = resolve_config_path()
+    assert result == str(env_config)
+
+
+def test_resolve_local_ralph_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scenario 3: ralph-config.yaml in CWD is found."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    local_config = tmp_path / "ralph-config.yaml"
+    local_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    result = resolve_config_path()
+    assert result == str(local_config.resolve())
+
+
+def test_resolve_repo_root_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scenario 4: ralph-config.yaml at host repo root (submodule case)."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+
+    # Simulate CWD inside a subdirectory (no local config).
+    subdir = tmp_path / "sub" / "module"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+
+    # Place config at the "repo root".
+    repo_root_config = tmp_path / "ralph-config.yaml"
+    repo_root_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    # Mock _get_repo_root to return tmp_path as the repo root.
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: tmp_path.resolve())
+
+    result = resolve_config_path()
+    assert result == str(repo_root_config.resolve())
+
+
+def test_resolve_global_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scenario 5: Falls back to global ~/.config/ralph-loop/config.yaml."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+
+    # CWD with no config.
+    cwd = tmp_path / "empty_cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    # No repo root.
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
+
+    # Set up a fake global config.
+    global_dir = tmp_path / "fakehome" / ".config" / "ralph-loop"
+    global_dir.mkdir(parents=True)
+    global_config = global_dir / "config.yaml"
+    global_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    monkeypatch.setattr("ralph_loop.config.GLOBAL_CONFIG_PATH", Path(str(global_config)))
+
+    result = resolve_config_path()
+    assert result == str(global_config.resolve())
+
+
+def test_resolve_no_config_raises_with_attempted_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scenario 6: No config anywhere — raises ConfigNotFoundError with paths."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+
+    cwd = tmp_path / "no_config"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
+
+    # Point global to a non-existent path.
+    fake_global = tmp_path / "nope" / "config.yaml"
+    monkeypatch.setattr("ralph_loop.config.GLOBAL_CONFIG_PATH", Path(str(fake_global)))
+
+    with pytest.raises(ConfigNotFoundError) as exc_info:
+        resolve_config_path()
+
+    error = exc_info.value
+    assert len(error.attempted) >= 2
+    assert str(cwd.resolve() / "ralph-config.yaml") in error.attempted
+    assert str(fake_global.resolve()) in error.attempted
+    assert "No ralph-loop config file found" in str(error)
+
+
+def test_resolve_repo_root_skipped_when_equals_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repo root step is skipped when it equals CWD (already checked in step 2)."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    # _get_repo_root returns CWD itself.
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: tmp_path.resolve())
+
+    # Point global to non-existent so we get an error with the attempted list.
+    fake_global = tmp_path / "nope" / "config.yaml"
+    monkeypatch.setattr("ralph_loop.config.GLOBAL_CONFIG_PATH", Path(str(fake_global)))
+
+    with pytest.raises(ConfigNotFoundError) as exc_info:
+        resolve_config_path()
+
+    # The repo root path should NOT appear in attempted (it was skipped).
+    attempted = exc_info.value.attempted
+    repo_candidate = str(tmp_path.resolve() / "ralph-config.yaml")
+    assert attempted.count(repo_candidate) == 1  # only from step 2, not step 3
+
+
+def test_resolve_git_not_available(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_get_repo_root returns None when git is not installed."""
+    from ralph_loop.config import _get_repo_root
+
+    def _fake_run(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    assert _get_repo_root() is None


### PR DESCRIPTION
## Summary
- Implement config resolution precedence when `--config` is omitted.
- Keep explicit `--config` behavior unchanged.
- Add submodule-aware host repo root lookup.
- Add/extend tests for explicit config, env var, local file, host repo root fallback, global fallback, and clear error paths.

## Resolution order
1. `--config` explicit path (existing behavior)
2. `RALPH_CONFIG` (if set)
3. `./ralph-config.yaml` (current working directory)
4. `<host-repo-root>/ralph-config.yaml` (via `git rev-parse --show-superproject-working-tree`, with safe fallback)
5. `~/.config/ralph-loop/config.yaml`
6. clear error including attempted paths

## Validation
- `ruff check ralph_loop/ tests/`
- `ruff format --check ralph_loop/ tests/`
- `mypy ralph_loop/`
- `python -B -m pytest tests/ -q`

All checks pass.

Closes #2