### PR TITLE
fix: ignore submodule-local config and prioritize host root

### DIFF
--- a/ralph_loop/config.py
+++ b/ralph_loop/config.py
@@ -13,6 +13,22 @@ LOCAL_CONFIG_FILENAME: str = "ralph-config.yaml"
 GLOBAL_CONFIG_PATH: Path = Path("~/.config/ralph-loop/config.yaml")
 
 
+def _get_superproject_root() -> Path | None:
+    """Return the host (superproject) root when running inside a submodule."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-superproject-working-tree"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip()).resolve()
+    except FileNotFoundError:
+        pass
+    return None
+
+
 def _get_repo_root() -> Path | None:
     """Return the host repo root, preferring the superproject when inside a submodule.
 
@@ -20,15 +36,9 @@ def _get_repo_root() -> Path | None:
     """
     try:
         # If we are a submodule, this returns the host (superproject) root.
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-superproject-working-tree"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        superproject = result.stdout.strip() if result.returncode == 0 else ""
+        superproject = _get_superproject_root()
         if superproject:
-            return Path(superproject).resolve()
+            return superproject
 
         # Not a submodule — fall back to the repo root.
         result = subprocess.run(
@@ -73,15 +83,18 @@ def resolve_config_path() -> str:
     if env_path:
         return env_path  # trust the user; existence checked by RalphConfig.load
 
-    # 2. Local ralph-config.yaml in CWD
+    superproject_root = _get_superproject_root()
+
+    # 2. Local ralph-config.yaml in CWD (skip when inside submodule)
     cwd = Path.cwd().resolve()
-    local_candidate = cwd / LOCAL_CONFIG_FILENAME
-    attempted.append(str(local_candidate))
-    if local_candidate.is_file():
-        return str(local_candidate)
+    if superproject_root is None:
+        local_candidate = cwd / LOCAL_CONFIG_FILENAME
+        attempted.append(str(local_candidate))
+        if local_candidate.is_file():
+            return str(local_candidate)
 
     # 3. Host repo root ralph-config.yaml
-    repo_root = _get_repo_root()
+    repo_root = superproject_root or _get_repo_root()
     if repo_root and repo_root != cwd:
         repo_candidate = repo_root / LOCAL_CONFIG_FILENAME
         attempted.append(str(repo_candidate))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,7 +135,8 @@ def test_resolve_repo_root_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     repo_root_config = tmp_path / "ralph-config.yaml"
     repo_root_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
 
-    # Mock _get_repo_root to return tmp_path as the repo root.
+    # Mock submodule host root to return tmp_path as the repo root.
+    monkeypatch.setattr("ralph_loop.config._get_superproject_root", lambda: tmp_path.resolve())
     monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: tmp_path.resolve())
 
     result = resolve_config_path()
@@ -151,6 +152,7 @@ def test_resolve_global_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     cwd.mkdir()
     monkeypatch.chdir(cwd)
 
+    monkeypatch.setattr("ralph_loop.config._get_superproject_root", lambda: None)
     # No repo root.
     monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
 
@@ -176,6 +178,7 @@ def test_resolve_no_config_raises_with_attempted_paths(
     cwd.mkdir()
     monkeypatch.chdir(cwd)
 
+    monkeypatch.setattr("ralph_loop.config._get_superproject_root", lambda: None)
     monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: None)
 
     # Point global to a non-existent path.
@@ -199,6 +202,7 @@ def test_resolve_repo_root_skipped_when_equals_cwd(
     monkeypatch.delenv("RALPH_CONFIG", raising=False)
     monkeypatch.chdir(tmp_path)
 
+    monkeypatch.setattr("ralph_loop.config._get_superproject_root", lambda: None)
     # _get_repo_root returns CWD itself.
     monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: tmp_path.resolve())
 
@@ -224,3 +228,26 @@ def test_resolve_git_not_available(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr("subprocess.run", _fake_run)
     assert _get_repo_root() is None
+
+
+def test_resolve_submodule_ignores_local_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When inside a submodule, local config is ignored in favor of host config."""
+    monkeypatch.delenv("RALPH_CONFIG", raising=False)
+
+    submodule_dir = tmp_path / "submodule"
+    submodule_dir.mkdir(parents=True)
+    monkeypatch.chdir(submodule_dir)
+
+    submodule_config = submodule_dir / "ralph-config.yaml"
+    submodule_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    host_config = tmp_path / "ralph-config.yaml"
+    host_config.write_text(_MINIMAL_CONFIG, encoding="utf-8")
+
+    monkeypatch.setattr("ralph_loop.config._get_superproject_root", lambda: tmp_path.resolve())
+    monkeypatch.setattr("ralph_loop.config._get_repo_root", lambda: tmp_path.resolve())
+
+    result = resolve_config_path()
+    assert result == str(host_config.resolve())


### PR DESCRIPTION
## Summary
- Update config resolution so submodule-local `ralph-config.yaml` is never used.
- When running inside a submodule, prioritize host repo root config.
- Preserve existing explicit precedence for `--config` and `RALPH_CONFIG`.
- Add test coverage for submodule ignore behavior.

## Behavior
- In submodule context:
  - ignore `./ralph-config.yaml` (submodule working dir)
  - use `<host-root>/ralph-config.yaml` when present
  - otherwise fall back to `~/.config/ralph-loop/config.yaml`

## Validation
- `ruff check ralph_loop/config.py tests/test_config.py`
- `ruff format --check ralph_loop/config.py tests/test_config.py`
- `mypy ralph_loop/`
- `python -B -m pytest tests/test_config.py tests/test_cli.py -q`

All checks pass.

Relates to #2
Closes #4
