### PR TITLE
fix: support positional loop dir in wrapper + root-config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,33 @@ Ships with 3 backends — **Codex**, **GitHub Copilot**, and **Claude Code** —
 
 ---
 
+## Root Config Workflow (Init → Run)
+
+If your `ralph-config.yaml` is in the repository root, and your plan is under `PRD/...`, run from repo root like this:
+
+```bash
+# 1) Initialize tasks/progress from a plan
+./ralph-loop init --from PRD/extractor_frames_desde_video/plan.md
+
+# 2) Execute loop against the generated loop directory
+./ralph-loop run PRD/extractor_frames_desde_video/.ralph-loop
+```
+
+Equivalent explicit form:
+
+```bash
+CONFIG=ralph-config.yaml LOOP_DIR=PRD/extractor_frames_desde_video/.ralph-loop ./ralph-loop run
+```
+
+Use the same `LOOP_DIR` for status/validation:
+
+```bash
+./ralph-loop status PRD/extractor_frames_desde_video/.ralph-loop
+./ralph-loop validate PRD/extractor_frames_desde_video/.ralph-loop
+```
+
+---
+
 ## What It Does
 
 ralph-loop takes a list of coding tasks (markdown files with YAML frontmatter) and iterates through them autonomously:

--- a/ralph-loop
+++ b/ralph-loop
@@ -183,6 +183,16 @@ build_backend_args() {
 }
 
 cmd_run() {
+    local args=("$@")
+    if [[ ${#args[@]} -gt 0 && "${args[0]}" != -* ]]; then
+        LOOP_DIR="${args[0]}"
+        args=("${args[@]:1}")
+    fi
+    if [[ ${#args[@]} -gt 0 ]]; then
+        log_error "Unknown arguments for run: ${args[*]}"
+        exit 1
+    fi
+
     ensure_image "base"
     for engine in $(run_base list-engines --config "/workspace/$CONFIG" 2>/dev/null); do
         ensure_image "$engine"
@@ -316,6 +326,16 @@ cmd_run() {
 }
 
 cmd_status() {
+    local args=("$@")
+    if [[ ${#args[@]} -gt 0 && "${args[0]}" != -* ]]; then
+        LOOP_DIR="${args[0]}"
+        args=("${args[@]:1}")
+    fi
+    if [[ ${#args[@]} -gt 0 ]]; then
+        log_error "Unknown arguments for status: ${args[*]}"
+        exit 1
+    fi
+
     ensure_image "base"
     run_base status --config "/workspace/$CONFIG" --loop-dir "/workspace/$LOOP_DIR"
 }
@@ -326,6 +346,16 @@ cmd_init() {
 }
 
 cmd_validate() {
+    local args=("$@")
+    if [[ ${#args[@]} -gt 0 && "${args[0]}" != -* ]]; then
+        LOOP_DIR="${args[0]}"
+        args=("${args[@]:1}")
+    fi
+    if [[ ${#args[@]} -gt 0 ]]; then
+        log_error "Unknown arguments for validate: ${args[*]}"
+        exit 1
+    fi
+
     ensure_image "base"
     run_base validate --config "/workspace/$CONFIG" --loop-dir "/workspace/$LOOP_DIR"
 }
@@ -346,6 +376,10 @@ case "$SUBCOMMAND" in
     build-images) cmd_build_images "$@" ;;
     help|--help|-h)
         echo "Usage: ralph-loop <run|status|init|validate|build-images>"
+        echo "  run [LOOP_DIR]"
+        echo "  status [LOOP_DIR]"
+        echo "  validate [LOOP_DIR]"
+        echo "  init [args...]"
         ;;
     *)
         log_error "Unknown command: $SUBCOMMAND"


### PR DESCRIPTION
## Summary
- Parse optional positional `LOOP_DIR` in the bash wrapper for `run`, `status`, and `validate`.
- Keep existing env-based usage (`CONFIG=... LOOP_DIR=... ./ralph-loop run`) fully compatible.
- Add an early README section documenting init + execution flow when config is in repo root.

## Changes
- `ralph-loop`
  - Accepts `run [LOOP_DIR]`, `status [LOOP_DIR]`, `validate [LOOP_DIR]`.
  - Emits clear error for unexpected extra args.
  - Updates help output examples.
- `README.md`
  - Adds "Root Config Workflow (Init → Run)" near the beginning with explicit commands.

## Validation
- `bash -n ralph-loop`
- `./ralph-loop help`

Closes #6