### PR TITLE
feat(init): support user directives in plan-to-tasks generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ Write a markdown file describing what you want to build:
 ./ralph-loop init --from plan.md
 ```
 
+You can steer task generation with additional directives:
+
+```bash
+./ralph-loop init \
+  --from plan.md \
+  --instructions "Review only at the end visually that all buttons are visible and legible"
+```
+
+Or provide a directives file:
+
+```bash
+./ralph-loop init --from plan.md --instructions-file generation-directives.md
+```
+
+Both flags are composable. When both are present, `--instructions-file` content is appended first,
+then `--instructions`.
+
 This creates a dedicated loop directory next to the plan:
 
 - `.ralph-loop/<plan-slug>/tasks/`
@@ -150,6 +167,35 @@ This creates a dedicated loop directory next to the plan:
 - `.ralph-loop/<plan-slug>/product/`
 
 It uses an AI backend to decompose your plan into structured, actionable tasks — or falls back to a deterministic parser if no backend is available.
+
+### How to influence `init` generation (LLM steering contract)
+
+`init` builds a single plan-to-tasks prompt from three sources (lowest to highest priority):
+
+1. `project_instructions` (auto-discovered `AGENTS.md` / `CLAUDE.md` / `COPILOT.md`, or explicit config)
+2. Source plan (`--from`)
+3. User directives (`--instructions-file`, then `--instructions`)
+
+Use directives to control generated task metadata, not only prose. The generator should emit tasks with
+frontmatter-compatible fields that drive the loop:
+
+- `acceptance_criteria`: concrete, testable checks.
+- `verify_commands`: deterministic commands executed in the generated `product/` workspace.
+- `visual_verify`: screenshot verification contract (`url`, `reference`, `assertion`, viewport).
+- `files_to_touch` / `files_not_to_touch`: implementation boundaries.
+- `constraints`: hard limits or guardrails for coding.
+
+Directive examples that reliably shape output:
+
+- `Review visually that the video list loads correctly.`
+  - Expected effect: attach `visual_verify` to the task that implements/renders the video list.
+- `Review only at the end visually that all buttons are displayed and legible.`
+  - Expected effect: attach `visual_verify` only to the final relevant task.
+- `Use verify_commands: python -m pytest -q tests and ruff check src`.
+  - Expected effect: include deterministic checks in generated tasks.
+
+Tip for best results: keep plans focused on deliverables, and place strict behavioral constraints in
+directives so they override inferred defaults.
 
 ### 3. Configure backends
 

--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -494,6 +494,19 @@ def _fallback_plan(source_text: str, title_hint: str) -> GeneratedPlan:
     return _apply_plan_hints(plan, source_text)
 
 
+def _contains_visual_instruction(text: str) -> bool:
+    lowered = text.lower()
+    markers = (
+        "visual verification",
+        "visual_verify",
+        "visual check",
+        "visually",
+        "visualmente",
+        "revisar visual",
+    )
+    return any(marker in lowered for marker in markers)
+
+
 def _extract_verify_command_hint(source_text: str) -> str | None:
     patterns = [
         r"`(python\s+-m\s+pytest[^`]+)`",
@@ -509,12 +522,20 @@ def _extract_verify_command_hint(source_text: str) -> str | None:
 
 def _extract_visual_verify_hint(source_text: str) -> VisualVerifyConfig | None:
     lowered = source_text.lower()
-    if "visual verification" not in lowered and "visual_verify" not in lowered:
+    if not _contains_visual_instruction(source_text):
         return None
 
-    reference_match = re.search(r"Reference image path:\s*`([^`]+)`", source_text)
-    assertion_match = re.search(r"Assertion:\s*(.+)", source_text)
-    url_match = re.search(r"URL:\s*`([^`]+)`", source_text)
+    reference_match = re.search(
+        r"(?:Reference image path|Imagen de referencia):\s*`([^`]+)`",
+        source_text,
+        flags=re.IGNORECASE,
+    )
+    assertion_match = re.search(
+        r"(?:Assertion|Aserción):\s*(.+)",
+        source_text,
+        flags=re.IGNORECASE,
+    )
+    url_match = re.search(r"URL:\s*`([^`]+)`", source_text, flags=re.IGNORECASE)
 
     if url_match:
         url = url_match.group(1).strip()
@@ -548,13 +569,38 @@ def _apply_plan_hints(plan: GeneratedPlan, source_text: str) -> GeneratedPlan:
     verify_hint = _extract_verify_command_hint(source_text)
     visual_hint = _extract_visual_verify_hint(source_text)
 
+    directive_text = source_text.lower()
+    visual_only_at_end = _is_final_only_visual_directive(directive_text)
+    visual_focus_terms = _extract_visual_focus_terms(directive_text)
+
     has_visual = False
+    flat_tasks: list[GeneratedTask] = []
     for phase in plan.phases:
         for task in phase.tasks:
+            flat_tasks.append(task)
             if verify_hint and not task.verify_commands:
                 task.verify_commands = [verify_hint]
             if task.visual_verify is not None:
                 has_visual = True
+
+    if visual_hint is not None and flat_tasks:
+        if visual_only_at_end:
+            target = _select_visual_target(flat_tasks, visual_focus_terms, prefer_last=True)
+            if target is None:
+                target = flat_tasks[-1]
+            for task in flat_tasks:
+                task.visual_verify = None
+            target.visual_verify = visual_hint
+            return plan
+
+        if visual_focus_terms:
+            target = _select_visual_target(flat_tasks, visual_focus_terms, prefer_last=False)
+            if target is not None:
+                for task in flat_tasks:
+                    if task is not target:
+                        task.visual_verify = None
+                target.visual_verify = visual_hint
+                return plan
 
     if visual_hint is not None and not has_visual:
         keywords = ("visual", "ui", "web", "index.html", "homepage", "page")
@@ -573,7 +619,90 @@ def _apply_plan_hints(plan: GeneratedPlan, source_text: str) -> GeneratedPlan:
     return plan
 
 
-def _build_prompt(source_content: str, config: RalphConfig) -> str:
+def _is_final_only_visual_directive(text: str) -> bool:
+    patterns = (
+        r"solo\s+al\s+final[^\n]*visual",
+        r"only\s+at\s+the\s+end[^\n]*visual",
+        r"visual[^\n]*only\s+at\s+the\s+end",
+        r"only\s+final[^\n]*visual",
+    )
+    return any(re.search(pattern, text) for pattern in patterns)
+
+
+def _extract_visual_focus_terms(text: str) -> list[str]:
+    patterns = (
+        r"(?:revisar|verificar|validar)\s+visualmente\s+que\s+([^\n\.;]+)",
+        r"(?:visually\s+(?:review|verify|check))(?:\s+that)?\s+([^\n\.;]+)",
+    )
+
+    phrase: str | None = None
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            phrase = match.group(1).strip()
+            break
+
+    if phrase is None:
+        return []
+
+    stop_words = {
+        "que",
+        "the",
+        "and",
+        "con",
+        "los",
+        "las",
+        "para",
+        "from",
+        "with",
+        "all",
+        "todos",
+        "todas",
+    }
+    terms: list[str] = []
+    for token in re.split(r"\W+", phrase):
+        normalized = token.strip().lower()
+        if len(normalized) < 3 or normalized in stop_words:
+            continue
+        if normalized not in terms:
+            terms.append(normalized)
+    return terms
+
+
+def _select_visual_target(
+    tasks: list[GeneratedTask],
+    focus_terms: list[str],
+    *,
+    prefer_last: bool,
+) -> GeneratedTask | None:
+    if not tasks:
+        return None
+
+    if focus_terms:
+        scored_matches: list[tuple[int, GeneratedTask]] = []
+        for task in tasks:
+            haystack = f"{task.title} {task.description}".lower()
+            score = sum(1 for term in focus_terms if term in haystack)
+            if score > 0:
+                scored_matches.append((score, task))
+        if scored_matches:
+            max_score = max(score for score, _task in scored_matches)
+            best_tasks = [task for score, task in scored_matches if score == max_score]
+            return best_tasks[-1] if prefer_last else best_tasks[0]
+
+    keywords = ("visual", "ui", "web", "index.html", "homepage", "page")
+    keyword_matches = [
+        task
+        for task in tasks
+        if any(keyword in f"{task.title} {task.description}".lower() for keyword in keywords)
+    ]
+    if keyword_matches:
+        return keyword_matches[-1] if prefer_last else keyword_matches[0]
+
+    return tasks[-1] if prefer_last else tasks[0]
+
+
+def _build_prompt(source_content: str, config: RalphConfig, user_directives: str = "") -> str:
     project_instructions = ""
     if config.project_instructions:
         instructions_path = Path(config.project_instructions)
@@ -581,7 +710,27 @@ def _build_prompt(source_content: str, config: RalphConfig) -> str:
             project_instructions = instructions_path.read_text(encoding="utf-8")
 
     template = _load_plan_template()
-    return template.render(source_content=source_content, project_instructions=project_instructions)
+    return template.render(
+        source_content=source_content,
+        project_instructions=project_instructions,
+        user_directives=user_directives,
+    )
+
+
+def _load_user_directives(instructions: str | None, instructions_file: Path | None) -> str:
+    chunks: list[str] = []
+
+    if instructions_file is not None:
+        file_content = instructions_file.read_text(encoding="utf-8").strip()
+        if file_content:
+            chunks.append(file_content)
+
+    if instructions:
+        inline_content = instructions.strip()
+        if inline_content:
+            chunks.append(inline_content)
+
+    return "\n\n".join(chunks)
 
 
 def _ensure_init_directories(config: RalphConfig) -> None:
@@ -1303,9 +1452,23 @@ def reset_command(task_id: str, config_path: str, loop_dir: str) -> None:
 @click.option("--from", "source_path", required=True)
 @click.option("--backend", required=False)
 @click.option("--model", required=False)
+@click.option(
+    "--instructions", required=False, help="Additional user directives for plan generation."
+)
+@click.option(
+    "--instructions-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=False,
+    help="Path to a file containing additional directives.",
+)
 @click.option("--config", "config_path", default=_default_config_path, show_default="auto")
 def init_command(
-    source_path: str, backend: str | None, model: str | None, config_path: str
+    source_path: str,
+    backend: str | None,
+    model: str | None,
+    instructions: str | None,
+    instructions_file: Path | None,
+    config_path: str,
 ) -> None:
     """Generate tasks and progress from a plan document."""
     source = Path(source_path)
@@ -1322,7 +1485,10 @@ def init_command(
 
     click.echo(f"[init] Reading source design: {source}")
     source_content = source.read_text(encoding="utf-8")
-    prompt = _build_prompt(source_content, config)
+    user_directives = _load_user_directives(instructions, instructions_file)
+    if user_directives:
+        click.echo("[init] Applying additional user directives.")
+    prompt = _build_prompt(source_content, config, user_directives)
 
     role_backend = (
         config.get_backend("inspector")
@@ -1347,9 +1513,13 @@ def init_command(
     if generated_plan is None:
         click.echo("[init] AI generation unavailable/invalid. Using deterministic fallback parser.")
         generated_plan = _fallback_plan(source_content, source.stem.replace("-", " ").title())
+        if user_directives:
+            generated_plan = _apply_plan_hints(
+                generated_plan, f"{source_content}\n\n{user_directives}"
+            )
     else:
         click.echo("[init] AI generation completed.")
-        generated_plan = _apply_plan_hints(generated_plan, source_content)
+        generated_plan = _apply_plan_hints(generated_plan, f"{source_content}\n\n{user_directives}")
 
     click.echo("[init] Writing tasks and progress files...")
     count, task_dir, progress_path = _write_generated_artifacts(context, generated_plan)

--- a/ralph_loop/prompts/plan_to_tasks.md.j2
+++ b/ralph_loop/prompts/plan_to_tasks.md.j2
@@ -44,6 +44,7 @@ Rules:
 - Do not prefix `verify_commands` with `cd tmp/product` (or any `cd` to the workspace path).
 - Include `visual_verify` for tasks that explicitly require visual checks.
 - If visual verification should inspect only the current screenshot, set `visual_verify.reference` to `null`.
+- If additional directives conflict with inferred hints, additional directives take precedence.
 - Output valid JSON with double quotes only.
 
 {% if project_instructions %}
@@ -53,3 +54,8 @@ Project instructions:
 
 Source plan:
 {{ source_content }}
+
+{% if user_directives %}
+Additional directives (highest priority):
+{{ user_directives }}
+{% endif %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,220 @@ Visual verification requirement:
     assert visual_tasks[0]["visual_verify"]["reference"] is None
 
 
+def test_init_includes_inline_instructions_in_prompt(sample_workspace: Path, monkeypatch) -> None:
+    captured_prompt: dict[str, str] = {}
+
+    class _FakeBackend:
+        def is_available(self) -> bool:
+            return True
+
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = model, timeout_seconds, extra_flags, cwd
+            captured_prompt["value"] = prompt
+            payload = {
+                "title": "Demo Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Create feature",
+                            }
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
+
+    plan_path = sample_workspace / "plan-inline-directives.md"
+    plan_path.write_text("# Plan\n- [ ] Create feature", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "init",
+            "--from",
+            str(plan_path),
+            "--instructions",
+            "Review visually that the video list renders correctly.",
+            "--config",
+            str(sample_workspace / "ralph-config.yaml"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Additional directives (highest priority):" in captured_prompt["value"]
+    assert "Review visually that the video list renders correctly." in captured_prompt["value"]
+
+
+def test_init_includes_instructions_file_and_inline_in_prompt(
+    sample_workspace: Path, monkeypatch
+) -> None:
+    captured_prompt: dict[str, str] = {}
+
+    class _FakeBackend:
+        def is_available(self) -> bool:
+            return True
+
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = model, timeout_seconds, extra_flags, cwd
+            captured_prompt["value"] = prompt
+            payload = {
+                "title": "Demo Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Create feature",
+                            }
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
+
+    plan_path = sample_workspace / "plan-file-directives.md"
+    plan_path.write_text("# Plan\n- [ ] Create feature", encoding="utf-8")
+
+    directives_path = sample_workspace / "directives.md"
+    directives_path.write_text(
+        "Check only at the end visually that all buttons are legible.",
+        encoding="utf-8",
+    )
+
+    inline_directive = "Review visually that the video list renders correctly."
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "init",
+            "--from",
+            str(plan_path),
+            "--instructions-file",
+            str(directives_path),
+            "--instructions",
+            inline_directive,
+            "--config",
+            str(sample_workspace / "ralph-config.yaml"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    prompt_value = captured_prompt["value"]
+    assert "Check only at the end visually that all buttons are legible." in prompt_value
+    assert inline_directive in prompt_value
+    assert prompt_value.index(
+        "Check only at the end visually that all buttons are legible."
+    ) < prompt_value.index(inline_directive)
+
+
+def test_init_fallback_visual_directive_only_at_end(sample_workspace: Path, monkeypatch) -> None:
+    class _UnavailableBackend:
+        def is_available(self) -> bool:
+            return False
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+
+    plan_path = sample_workspace / "plan-visual-end-only.md"
+    plan_path.write_text(
+        """# Plan
+
+- [ ] Build homepage layout
+- [ ] Improve homepage button readability
+""",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "init",
+            "--from",
+            str(plan_path),
+            "--instructions",
+            "Revisar solo al final visualmente que todos los botones estén desplegados y sean legibles.",
+            "--config",
+            str(sample_workspace / "ralph-config.yaml"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    progress = yaml.safe_load((sample_workspace / "PROGRESS.yaml").read_text(encoding="utf-8"))
+    tasks = progress["phases"][0]["tasks"]
+    visual_tasks = [task for task in tasks if task["visual_verify"] is not None]
+    assert len(visual_tasks) == 1
+    assert visual_tasks[0]["id"] == "02"
+
+
+def test_init_fallback_visual_directive_targets_specific_task(
+    sample_workspace: Path, monkeypatch
+) -> None:
+    class _UnavailableBackend:
+        def is_available(self) -> bool:
+            return False
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+
+    plan_path = sample_workspace / "plan-visual-targeted.md"
+    plan_path.write_text(
+        """# Plan
+
+- [ ] Crear API de videos
+- [ ] Renderizar lista de videos
+- [ ] Añadir tests
+""",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "init",
+            "--from",
+            str(plan_path),
+            "--instructions",
+            "Revisar visualmente que la lista de videos se obtiene correctamente.",
+            "--config",
+            str(sample_workspace / "ralph-config.yaml"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    progress = yaml.safe_load((sample_workspace / "PROGRESS.yaml").read_text(encoding="utf-8"))
+    tasks = progress["phases"][0]["tasks"]
+    visual_tasks = [task for task in tasks if task["visual_verify"] is not None]
+    assert len(visual_tasks) == 1
+    assert visual_tasks[0]["id"] == "02"
+
+
 def test_init_creates_target_directories_when_missing(sample_workspace: Path, monkeypatch) -> None:
     config_path = sample_workspace / "ralph-config.missing-dirs.yaml"
     workspace_dir = sample_workspace / "generated" / "workspace"


### PR DESCRIPTION
## Summary

Implements issue #8 by extending `init` plan generation with additional user directives.

### What changed

- Added CLI options to `init`:
  - `--instructions` (inline directives)
  - `--instructions-file` (file-based directives)
- Added prompt precedence and directive injection in plan-to-tasks template.
- Extended fallback hint logic to respect visual directives, including:
  - final-only visual checks
  - targeted visual checks from directive wording
- Added tests for prompt inclusion/order and fallback visual targeting behavior.
- Updated `README.md` with enough structure/contract detail so an LLM can influence generation through directives.

### Validation

- `pytest tests/ -v` (full suite): passed
- `ruff check ralph_loop/ tests/`: passed
- `ruff format --check ralph_loop/ tests/`: passed
- `mypy ralph_loop/`: passed

Closes #8.
