### PR TITLE
fix(init): enforce AI-only generation (remove deterministic fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ralph-loop takes a list of coding tasks (markdown files with YAML frontmatter) a
 - **Visual screenshot verification** — optional Playwright-based screenshot capture reviewed by AI, with or without a reference image.
 - **Run ALL verifiers every attempt** — deterministic tests, AI inspection, and visual checks all run regardless of individual failures, maximizing signal per retry.
 - **Docker-isolated per-backend containers** — each AI CLI runs in its own container with only the credentials it needs. No Docker socket mount.
-- **Plan-to-tasks generation** — convert a markdown plan into structured task files and a PROGRESS.yaml tracker, using AI or a deterministic fallback.
+- **Plan-to-tasks generation** — convert a markdown plan into structured task files and a PROGRESS.yaml tracker, using AI generation.
 - **Pause/resume** — drop a `PAUSE.md` file to pause the loop; remove it to resume.
 - **Retry-first scheduling** — failed tasks are retried before new tasks are started.
 - **Phase-based progression** — tasks are grouped into phases; the loop advances to the next phase when all tasks in the current phase are done or aborted.
@@ -166,7 +166,7 @@ This creates a dedicated loop directory next to the plan:
 - `.ralph-loop/<plan-slug>/PROGRESS.yaml`
 - `.ralph-loop/<plan-slug>/product/`
 
-It uses an AI backend to decompose your plan into structured, actionable tasks — or falls back to a deterministic parser if no backend is available.
+It uses an AI backend to decompose your plan into structured, actionable tasks.
 
 ### How to influence `init` generation (LLM steering contract)
 

--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -1511,15 +1511,13 @@ def init_command(
         model_override=model,
     )
     if generated_plan is None:
-        click.echo("[init] AI generation unavailable/invalid. Using deterministic fallback parser.")
-        generated_plan = _fallback_plan(source_content, source.stem.replace("-", " ").title())
-        if user_directives:
-            generated_plan = _apply_plan_hints(
-                generated_plan, f"{source_content}\n\n{user_directives}"
-            )
-    else:
-        click.echo("[init] AI generation completed.")
-        generated_plan = _apply_plan_hints(generated_plan, f"{source_content}\n\n{user_directives}")
+        raise click.ClickException(
+            "AI generation unavailable or invalid backend output. "
+            "`init` requires AI generation and does not support deterministic fallback."
+        )
+
+    click.echo("[init] AI generation completed.")
+    generated_plan = _apply_plan_hints(generated_plan, f"{source_content}\n\n{user_directives}")
 
     click.echo("[init] Writing tasks and progress files...")
     count, task_dir, progress_path = _write_generated_artifacts(context, generated_plan)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,9 +124,7 @@ def test_init_command_generates_files_with_backend_output(
     assert payload["phases"][0]["tasks"][0]["visual_verify"]["reference"] == "references/home.jpg"
 
 
-def test_init_command_falls_back_when_backend_unavailable(
-    sample_workspace: Path, monkeypatch
-) -> None:
+def test_init_command_fails_when_backend_unavailable(sample_workspace: Path, monkeypatch) -> None:
     class _UnavailableBackend:
         def is_available(self) -> bool:
             return False
@@ -147,18 +145,85 @@ def test_init_command_falls_back_when_backend_unavailable(
             str(sample_workspace / "ralph-config.yaml"),
         ],
     )
-    assert result.exit_code == 0
-
-    assert (sample_workspace / "tasks" / "01-first-task.md").exists()
-    assert (sample_workspace / "tasks" / "02-second-task.md").exists()
+    assert result.exit_code != 0
+    assert "requires AI generation" in result.output
 
 
-def test_init_fallback_applies_verify_and_visual_hints(sample_workspace: Path, monkeypatch) -> None:
-    class _UnavailableBackend:
+def test_init_command_fails_when_backend_output_is_invalid(
+    sample_workspace: Path, monkeypatch
+) -> None:
+    class _InvalidBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+
+            class _Result:
+                exit_code = 0
+                stdout = "not-json"
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _InvalidBackend())
+
+    plan_path = sample_workspace / "plan-invalid-output.md"
+    plan_path.write_text("# Plan\n- [ ] First task", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "init",
+            "--from",
+            str(plan_path),
+            "--config",
+            str(sample_workspace / "ralph-config.yaml"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "requires AI generation" in result.output
+
+
+def test_init_applies_verify_and_visual_hints(sample_workspace: Path, monkeypatch) -> None:
+    class _FakeBackend:
+        def is_available(self) -> bool:
+            return True
+
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Visual Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Build homepage",
+                                "description": "Build homepage",
+                            },
+                            {"id": "02", "title": "Add tests", "description": "Add tests"},
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = sample_workspace / "plan-visual.md"
     plan_path.write_text(
@@ -200,14 +265,36 @@ Verification:
     assert any(task["visual_verify"] is not None for task in tasks)
 
 
-def test_init_fallback_applies_visual_hint_without_reference(
-    sample_workspace: Path, monkeypatch
-) -> None:
-    class _UnavailableBackend:
+def test_init_applies_visual_hint_without_reference(sample_workspace: Path, monkeypatch) -> None:
+    class _FakeBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Visual Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {"id": "01", "title": "Build homepage", "description": "Build homepage"}
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = sample_workspace / "plan-visual-no-reference.md"
     plan_path.write_text(
@@ -377,12 +464,45 @@ def test_init_includes_instructions_file_and_inline_in_prompt(
     ) < prompt_value.index(inline_directive)
 
 
-def test_init_fallback_visual_directive_only_at_end(sample_workspace: Path, monkeypatch) -> None:
-    class _UnavailableBackend:
+def test_init_visual_directive_only_at_end(sample_workspace: Path, monkeypatch) -> None:
+    class _FakeBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Directive Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Build homepage layout",
+                                "description": "Build homepage layout",
+                            },
+                            {
+                                "id": "02",
+                                "title": "Improve homepage button readability",
+                                "description": "Improve homepage button readability",
+                            },
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = sample_workspace / "plan-visual-end-only.md"
     plan_path.write_text(
@@ -416,14 +536,50 @@ def test_init_fallback_visual_directive_only_at_end(sample_workspace: Path, monk
     assert visual_tasks[0]["id"] == "02"
 
 
-def test_init_fallback_visual_directive_targets_specific_task(
-    sample_workspace: Path, monkeypatch
-) -> None:
-    class _UnavailableBackend:
+def test_init_visual_directive_targets_specific_task(sample_workspace: Path, monkeypatch) -> None:
+    class _FakeBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Directive Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Crear API de videos",
+                                "description": "Crear API de videos",
+                            },
+                            {
+                                "id": "02",
+                                "title": "Renderizar lista de videos",
+                                "description": "Renderizar lista de videos",
+                            },
+                            {
+                                "id": "03",
+                                "title": "Añadir tests",
+                                "description": "Añadir tests",
+                            },
+                        ],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+                duration_seconds = 0.1
+                timed_out = False
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = sample_workspace / "plan-visual-targeted.md"
     plan_path.write_text(
@@ -474,11 +630,31 @@ def test_init_creates_target_directories_when_missing(sample_workspace: Path, mo
     config_payload["pause_file"] = str(pause_file)
     config_path.write_text(yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8")
 
-    class _UnavailableBackend:
+    class _FakeBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Setup Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [{"id": "01", "title": "Setup project"}],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = sample_workspace / "plan-missing-dirs.md"
     plan_path.write_text("# Plan\n- [ ] Setup project", encoding="utf-8")
@@ -523,11 +699,31 @@ def test_init_uses_derived_loop_directory_with_global_config(tmp_path: Path, mon
         encoding="utf-8",
     )
 
-    class _UnavailableBackend:
+    class _FakeBackend:
         def is_available(self) -> bool:
-            return False
+            return True
 
-    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _UnavailableBackend())
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = prompt, model, timeout_seconds, extra_flags, cwd
+            payload = {
+                "title": "Setup Plan",
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "tasks": [{"id": "01", "title": "Setup project"}],
+                    }
+                ],
+            }
+
+            class _Result:
+                exit_code = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+
+            return _Result()
+
+    monkeypatch.setattr("ralph_loop.cli.get_backend", lambda engine: _FakeBackend())
 
     plan_path = workspace / "my-feature-plan.md"
     plan_path.write_text("# Plan\n- [ ] Setup project", encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR enforces AI-only behavior for `init` generation.

### Changes

- Remove deterministic fallback behavior from `init` when backend is unavailable/invalid.
- Fail fast with a clear error message when AI generation cannot produce valid output.
- Update CLI tests to reflect AI-only behavior.
- Update `README.md` wording to remove fallback references for plan-to-tasks generation.

### Why

`init` directives should always be interpreted by AI generation. Deterministic fallback ignored those higher-level directives and produced overly granular tasks.

### Validation

- `ruff check ralph_loop/cli.py tests/test_cli.py`
- `ruff format --check ralph_loop/cli.py tests/test_cli.py`
- `mypy ralph_loop/`
- `python -B -m pytest tests/ -v`

