### PR TITLE
fix(init): run docker init in selected backend image with auth forwarding

### DIFF
--- a/ralph-loop
+++ b/ralph-loop
@@ -111,6 +111,49 @@ run_cli() {
     docker run --rm -u "$DOCKER_USER" -v "$PWD:/workspace" "${auth_env[@]}" "${auth_mount[@]}" "$image" "$@"
 }
 
+run_cli_with_auth_file() {
+    local image="$1"; shift
+    local auth_file="$1"; shift
+    local auth_env=() auth_mount=()
+    local container_home="/home/ralph"
+
+    while IFS= read -r env_var; do
+        [[ -n "${!env_var:-}" ]] && auth_env+=("-e" "$env_var")
+    done < <(jq -r '.env[]? // empty' "$auth_file")
+
+    while IFS= read -r mount_path; do
+        expanded="${mount_path/#\~/$HOME}"
+        if [[ -d "$expanded" ]]; then
+            if [[ "$mount_path" == "~/"* ]]; then
+                container_target="${container_home}/${mount_path:2}"
+            else
+                container_target="$expanded"
+            fi
+            auth_mount+=("-v" "${expanded}:${container_target}")
+        fi
+    done < <(jq -r '.mount[]? // empty' "$auth_file")
+
+    docker run --rm -u "$DOCKER_USER" -v "$PWD:/workspace" "${auth_env[@]}" "${auth_mount[@]}" "$image" "$@"
+}
+
+extract_init_backend_override() {
+    local args=("$@")
+    local index
+    for ((index=0; index<${#args[@]}; index++)); do
+        if [[ "${args[index]}" == "--backend" ]]; then
+            if (( index + 1 < ${#args[@]} )); then
+                echo "${args[index + 1]}"
+                return
+            fi
+        fi
+        if [[ "${args[index]}" == --backend=* ]]; then
+            echo "${args[index]#--backend=}"
+            return
+        fi
+    done
+    echo ""
+}
+
 run_trusted_verify_cmd() {
     local cwd="$1"
     local cmd="$2"
@@ -341,8 +384,31 @@ cmd_status() {
 }
 
 cmd_init() {
+    local args=("$@")
     ensure_image "base"
-    run_base init "$@"
+
+    local engine
+    engine=$(extract_init_backend_override "${args[@]}")
+    if [[ -z "$engine" ]]; then
+        engine=$(run_base init-engine --config "/workspace/$CONFIG")
+    fi
+
+    case "$engine" in
+        codex|copilot|claude) ;;
+        *)
+            log_error "Unsupported backend for init: $engine"
+            exit 1
+            ;;
+    esac
+
+    ensure_image "$engine"
+
+    mkdir -p "$RALPH_TMP"
+    local auth_file="$RALPH_TMP/init-auth.json"
+    run_base auth-config --engine "$engine" --config "/workspace/$CONFIG" > "$auth_file"
+
+    log_info "Running init with backend image: ralph-loop-$engine"
+    run_cli_with_auth_file "ralph-loop-$engine" "$auth_file" init "${args[@]}"
 }
 
 cmd_validate() {

--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -956,6 +956,28 @@ def list_engines_command(config_path: str) -> None:
         click.echo(engine)
 
 
+@main.command("init-engine")
+@click.option("--config", "config_path", default=_default_config_path, show_default="auto")
+def init_engine_command(config_path: str) -> None:
+    """Print the engine used by `init` plan generation."""
+    config = _load_config(config_path)
+    role_backend = (
+        config.get_backend("inspector")
+        if "inspector" in config.backends
+        else config.get_backend("coder")
+    )
+    click.echo(role_backend.engine)
+
+
+@main.command("auth-config")
+@click.option("--engine", required=True)
+@click.option("--config", "config_path", default=_default_config_path, show_default="auto")
+def auth_config_command(engine: str, config_path: str) -> None:
+    """Print auth forwarding config for an engine as JSON."""
+    config = _load_config(config_path)
+    click.echo(json.dumps(config.get_auth(engine).model_dump()))
+
+
 @main.command("validate")
 @click.option("--config", "config_path", default=_default_config_path, show_default="auto")
 @click.option("--loop-dir", default=".", show_default=True)


### PR DESCRIPTION
## Summary

Fixes Docker `init` execution so AI generation actually runs in a backend image that contains the selected CLI.

## Problem

`./ralph-loop init` was always executed in `ralph-loop-base`, which does not include `copilot`, `codex`, or `claude` binaries. With AI-only init, this caused immediate failure:

- AI generation unavailable/invalid backend output

## Changes

- Add CLI helper commands:
  - `init-engine` (prints engine used by `init`)
  - `auth-config --engine` (prints auth forwarding JSON for engine)
- Update wrapper `cmd_init` to:
  - resolve backend from `--backend` or config default (`init-engine`)
  - ensure backend image is built (`ralph-loop-<engine>`)
  - load auth config for selected engine
  - run `init` inside backend image with env/mount forwarding

## Validation

- `ruff check ralph_loop/ tests/`
- `ruff format --check ralph_loop/ tests/`
- `mypy ralph_loop/`
- `python -B -m pytest tests/ -q`

All passed.
