### PR TITLE
feat: recover orphan in-progress tasks at startup

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2094,7 +2094,7 @@ Not a Python CLI command — handled by the bash script directly.
 | `.ralph-tmp/` exists from previous run | Cleared by bash script at startup (`rm -rf .ralph-tmp && mkdir .ralph-tmp`) |
 | SIGINT (Ctrl+C) during loop | Bash trap cleans up `.ralph-tmp/`, exits with 130 |
 | SIGTERM | Same as SIGINT |
-| Task locked (IN_PROGRESS) at startup | If iteration-state.json exists, resume mid-iteration; otherwise reset to FAILED |
+| Task locked (IN_PROGRESS) at startup | Prompt user to recover (reset to FAILED) or abort the loop |
 | Concurrent runs | Not supported; `.ralph-tmp/` acts as implicit lock. Second run detects existing dir and warns. |
 
 ---

--- a/ralph-loop
+++ b/ralph-loop
@@ -298,6 +298,20 @@ cmd_run() {
         log_info "Next action: $COMMAND (task: $TASK_ID)"
 
         case "$COMMAND" in
+            orphan)
+                TASK_IDS=$(jq -r '.task_ids[]? // empty' "$RALPH_TMP/next-action.json" | paste -sd ', ' -)
+                [[ -z "$TASK_IDS" ]] && TASK_IDS="unknown"
+                log_warn "Detected orphan in-progress tasks: $TASK_IDS"
+                printf "[ralph] Recover orphan tasks and continue? [y/N]: "
+                read -r RECOVER_ORPHAN
+                if [[ "$RECOVER_ORPHAN" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+                    run_base recover --config "/workspace/$CONFIG" --loop-dir "/workspace/$LOOP_DIR" --task-id all >/dev/null
+                    log_info "Recovered orphan tasks. Continuing loop..."
+                    continue
+                fi
+                log_error "Loop aborted by user due to orphan in-progress tasks."
+                cleanup 1
+                ;;
             code)
                 IMAGE=$(jq -r '.image' "$RALPH_TMP/next-action.json")
                 build_backend_args

--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -32,9 +32,11 @@ from ralph_loop.progress import (
     TaskStatus,
     complete_task,
     fail_task,
+    find_in_progress_tasks,
     find_task,
     load_progress,
     lock_task,
+    recover_in_progress_task,
     save_progress,
     select_next_task,
 )
@@ -1190,6 +1192,21 @@ def next_action_command(config_path: str, loop_dir: str, step_result_path: str |
 
     if iteration is not None and iteration.get("current_step") == "update":
         _clear_iteration_state(paths.iteration_path)
+        iteration = None
+
+    if iteration is None:
+        in_progress_tasks = find_in_progress_tasks(progress)
+        if in_progress_tasks:
+            click.echo(
+                json.dumps(
+                    {
+                        "command": "orphan",
+                        "task_ids": [task.id for task in in_progress_tasks],
+                        "reason": "orphan_in_progress",
+                    }
+                )
+            )
+            return
 
     aborted_task = _first_aborted_task(progress)
     if aborted_task is not None:
@@ -1471,6 +1488,30 @@ def reset_command(task_id: str, config_path: str, loop_dir: str) -> None:
 
     save_progress(progress, config.progress_file)
     click.echo(f"Task reset: {task_id}")
+
+
+@main.command("recover")
+@click.option("--config", "config_path", default=_default_config_path, show_default="auto")
+@click.option("--loop-dir", default=".", show_default=True)
+@click.option("--task-id", default="all", show_default=True)
+def recover_command(config_path: str, loop_dir: str, task_id: str) -> None:
+    """Recover orphan tasks left in in_progress state."""
+    config, progress = _load_config_and_progress(config_path, loop_dir)
+
+    if task_id == "all":
+        task_ids = [task.id for task in find_in_progress_tasks(progress)]
+    else:
+        task_ids = [task_id]
+
+    recovered: list[str] = []
+    for pending_task_id in task_ids:
+        recover_in_progress_task(progress, pending_task_id, config.max_retries)
+        recovered.append(pending_task_id)
+
+    if recovered:
+        save_progress(progress, config.progress_file)
+
+    click.echo(json.dumps({"recovered": recovered}))
 
 
 @main.command("init")

--- a/ralph_loop/loop.py
+++ b/ralph_loop/loop.py
@@ -18,8 +18,10 @@ from ralph_loop.progress import (
     advance_phase,
     complete_task,
     fail_task,
+    find_in_progress_tasks,
     load_progress,
     lock_task,
+    recover_in_progress_task,
     save_progress,
     select_next_task,
 )
@@ -30,6 +32,10 @@ from ralph_loop.verification.pipeline import run_verification_pipeline
 def run_loop(config: RalphConfig, sandbox: str = "none") -> int:
     """Run native orchestration loop for configured tasks."""
     _setup_signal_handlers()
+    progress = load_progress(config.progress_file)
+    if not _handle_orphan_tasks(progress, config):
+        return 1
+    save_progress(progress, config.progress_file)
 
     while True:
         if Path(config.pause_file).exists():
@@ -159,3 +165,25 @@ def _setup_signal_handlers() -> None:
 
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
+
+
+def _handle_orphan_tasks(progress: Progress, config: RalphConfig) -> bool:
+    orphan_tasks = find_in_progress_tasks(progress)
+    if not orphan_tasks:
+        return True
+
+    task_ids = ", ".join(task.id for task in orphan_tasks)
+    print(f"[ralph] Found orphan in-progress tasks: {task_ids}")
+    print("[ralph] Choose action: [r]eset tasks to failed and continue, [a]bort loop")
+
+    while True:
+        choice = input("[ralph] Action (r/a): ").strip().lower()
+        if choice in {"a", "abort"}:
+            print("[ralph] Loop aborted by user.")
+            return False
+        if choice in {"r", "reset"}:
+            for task in orphan_tasks:
+                recover_in_progress_task(progress, task.id, config.max_retries)
+            print(f"[ralph] Recovered orphan tasks: {task_ids}")
+            return True
+        print("[ralph] Invalid option. Enter 'r' to reset and continue, or 'a' to abort.")

--- a/ralph_loop/progress.py
+++ b/ralph_loop/progress.py
@@ -131,8 +131,22 @@ def _set_phase_status_for_task(progress: Progress, task_id: str, status: PhaseSt
             return
 
 
+def _recalculate_phase_status(phase: PhaseProgress) -> None:
+    if all(task.status in {TaskStatus.COMPLETED, TaskStatus.ABORT} for task in phase.tasks):
+        phase.status = PhaseStatus.COMPLETED
+        return
+    if any(task.status in {TaskStatus.IN_PROGRESS, TaskStatus.FAILED} for task in phase.tasks):
+        phase.status = PhaseStatus.IN_PROGRESS
+        return
+    phase.status = PhaseStatus.NOT_STARTED
+
+
 def select_next_task(progress: Progress, max_retries: int = 3) -> TaskProgress | None:
-    """Select the next task honoring retry-first policy and current phase preference."""
+    """Select the next task honoring retry-first policy and current phase preference.
+
+    Tasks in ``IN_PROGRESS`` are intentionally excluded from selection. Callers should handle
+    orphaned in-progress tasks before requesting the next task.
+    """
     current_phase_id = progress.meta.current_phase
 
     def collect(predicate: Callable[[TaskProgress], bool]) -> list[TaskProgress]:
@@ -158,6 +172,39 @@ def select_next_task(progress: Progress, max_retries: int = 3) -> TaskProgress |
         return not_started[0]
 
     return None
+
+
+def find_in_progress_tasks(progress: Progress) -> list[TaskProgress]:
+    """Return all tasks currently locked in IN_PROGRESS."""
+    return [
+        task
+        for phase in progress.phases
+        for task in phase.tasks
+        if task.status == TaskStatus.IN_PROGRESS
+    ]
+
+
+def recover_in_progress_task(progress: Progress, task_id: str, max_retries: int = 3) -> None:
+    """Recover a task left in IN_PROGRESS after interruption.
+
+    Recovery transitions ``IN_PROGRESS`` tasks to ``FAILED`` (or ``ABORT`` if retries already
+    exhausted) while preserving retries and accumulated feedback.
+    """
+    task = find_task(progress, task_id)
+    if task.status != TaskStatus.IN_PROGRESS:
+        raise ValueError(
+            f"Illegal transition {task.status.value} -> failed/abort for task {task_id}"
+        )
+
+    if task.retries >= max_retries:
+        task.status = TaskStatus.ABORT
+    else:
+        task.status = TaskStatus.FAILED
+
+    for phase in progress.phases:
+        if any(member.id == task_id for member in phase.tasks):
+            _recalculate_phase_status(phase)
+            return
 
 
 def lock_task(progress: Progress, task_id: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1175,6 +1175,54 @@ def test_next_action_returns_abort_when_any_task_is_aborted(
     assert payload["task_id"] == "01"
 
 
+def test_next_action_returns_orphan_when_task_is_in_progress(
+    sample_workspace: Path, monkeypatch
+) -> None:
+    config_path = sample_workspace / "ralph-config.yaml"
+    progress_path = sample_workspace / "PROGRESS.yaml"
+
+    progress = load_progress(str(progress_path))
+    progress.phases[0].tasks[0].status = TaskStatus.IN_PROGRESS
+    save_progress(progress, str(progress_path))
+
+    config = RalphConfig.load(str(config_path))
+    original_exists = Path.exists
+
+    def _patched_exists(path: Path) -> bool:
+        if path.resolve() == Path(config.pause_file).resolve():
+            return False
+        return original_exists(path)
+
+    monkeypatch.setattr("ralph_loop.cli.Path.exists", _patched_exists)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["next-action", "--config", str(config_path)])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["command"] == "orphan"
+    assert payload["task_ids"] == ["01"]
+
+
+def test_recover_command_resets_orphan_task_to_failed(sample_workspace: Path) -> None:
+    config_path = sample_workspace / "ralph-config.yaml"
+    progress_path = sample_workspace / "PROGRESS.yaml"
+
+    progress = load_progress(str(progress_path))
+    progress.phases[0].tasks[0].status = TaskStatus.IN_PROGRESS
+    progress.phases[0].tasks[0].retries = 1
+    save_progress(progress, str(progress_path))
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["recover", "--config", str(config_path), "--task-id", "all"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["recovered"] == ["01"]
+
+    updated = load_progress(str(progress_path))
+    assert updated.phases[0].tasks[0].status == TaskStatus.FAILED
+    assert updated.phases[0].tasks[0].retries == 1
+
+
 def test_update_command_fails_task_when_visual_step_fails(sample_workspace: Path) -> None:
     config_path = sample_workspace / "ralph-config.yaml"
     config = RalphConfig.load(str(config_path))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,6 +145,99 @@ def test_full_loop_pass_retry_abort(monkeypatch, tmp_path: Path) -> None:
     assert len(task_03.feedback) == 3
 
 
+def test_run_loop_recovers_orphan_in_progress_task(monkeypatch, tmp_path: Path) -> None:
+    workspace = tmp_path
+    tasks_dir = workspace / "tasks"
+    tasks_dir.mkdir()
+
+    _write_task(tasks_dir / "01-task.md", "Task 01", "verify-01")
+
+    progress_path = workspace / "PROGRESS.yaml"
+    progress_path.write_text(
+        yaml.safe_dump(
+            {
+                "meta": {"title": "Integration", "started": "2026-03-01", "current_phase": 1},
+                "phases": [
+                    {
+                        "id": 1,
+                        "name": "Phase 1",
+                        "status": "in_progress",
+                        "tasks": [
+                            {
+                                "id": "01",
+                                "title": "Task 01",
+                                "task_file": str(tasks_dir / "01-task.md"),
+                                "status": "in_progress",
+                                "retries": 0,
+                                "verify_commands": ["verify-01"],
+                                "visual_verify": None,
+                                "feedback": [],
+                            }
+                        ],
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config = RalphConfig.model_validate(
+        {
+            "workspace_dir": str(workspace),
+            "progress_file": str(progress_path),
+            "task_dir": str(tasks_dir),
+            "max_retries": 3,
+            "pause_file": str(workspace / "PAUSE.md"),
+            "backends": {
+                "coder": {"engine": "codex", "timeout_seconds": 60},
+                "inspector": {"engine": "copilot", "timeout_seconds": 60},
+            },
+            "verify_commands": [],
+        }
+    )
+
+    class _Backend:
+        def __init__(self, engine: str) -> None:
+            self.engine = engine
+
+        @property
+        def name(self) -> str:
+            return self.engine
+
+        def execute(self, prompt: str, model=None, timeout_seconds=600, extra_flags=None, cwd=None):
+            _ = model, timeout_seconds, extra_flags, cwd
+            if self.engine == "copilot":
+                return SimpleNamespace(
+                    exit_code=0,
+                    stdout='{"verdict":"pass","feedback":"ok"}',
+                    stderr="",
+                    timed_out=False,
+                )
+            return SimpleNamespace(exit_code=0, stdout="coded", stderr="", timed_out=False)
+
+        def is_available(self) -> bool:
+            return True
+
+    monkeypatch.setattr("ralph_loop.loop.get_backend", lambda engine: _Backend(engine))
+    monkeypatch.setattr("builtins.input", lambda _: "r")
+
+    def _fake_run(command, cwd, capture_output, text, check):
+        _ = cwd, capture_output, text, check
+        if command[:3] == ["git", "--no-pager", "diff"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    exit_code = run_loop(config, sandbox="none")
+    assert exit_code == 0
+
+    progress = load_progress(str(progress_path))
+    task_01 = progress.phases[0].tasks[0]
+    assert task_01.status.value == "completed"
+
+
 def _write_task(path: Path, title: str, verify_command: str) -> None:
     path.write_text(
         f"""---

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from ralph_loop.progress import (
     FeedbackEntry,
     Progress,
@@ -9,8 +11,10 @@ from ralph_loop.progress import (
     advance_phase,
     complete_task,
     fail_task,
+    find_in_progress_tasks,
     load_progress,
     lock_task,
+    recover_in_progress_task,
     save_progress,
     select_next_task,
 )
@@ -57,3 +61,39 @@ def test_advance_phase_false_when_single_phase(sample_workspace: Path) -> None:
     lock_task(progress, "01")
     complete_task(progress, "01")
     assert advance_phase(progress) is False
+
+
+def test_find_in_progress_tasks_returns_locked_tasks(sample_workspace: Path) -> None:
+    progress = load_progress(str(sample_workspace / "PROGRESS.yaml"))
+    lock_task(progress, "01")
+
+    locked = find_in_progress_tasks(progress)
+
+    assert [task.id for task in locked] == ["01"]
+
+
+def test_recover_in_progress_task_to_failed(sample_workspace: Path) -> None:
+    progress = load_progress(str(sample_workspace / "PROGRESS.yaml"))
+    lock_task(progress, "01")
+
+    recover_in_progress_task(progress, "01", max_retries=3)
+
+    assert progress.phases[0].tasks[0].status == TaskStatus.FAILED
+
+
+def test_recover_in_progress_task_to_abort_when_retries_exhausted(sample_workspace: Path) -> None:
+    progress = load_progress(str(sample_workspace / "PROGRESS.yaml"))
+    task = progress.phases[0].tasks[0]
+    task.status = TaskStatus.IN_PROGRESS
+    task.retries = 3
+
+    recover_in_progress_task(progress, "01", max_retries=3)
+
+    assert progress.phases[0].tasks[0].status == TaskStatus.ABORT
+
+
+def test_recover_in_progress_task_rejects_non_in_progress(sample_workspace: Path) -> None:
+    progress = load_progress(str(sample_workspace / "PROGRESS.yaml"))
+
+    with pytest.raises(ValueError):
+        recover_in_progress_task(progress, "01", max_retries=3)


### PR DESCRIPTION
## Summary
- detect orphan tasks in `in_progress` during startup
- add explicit recovery flow to abort loop or reset orphan task
- wire recovery command in CLI and bash orchestrator
- add tests for progress, CLI, and integration recovery paths
- update design doc to reflect startup orphan handling

## Validation
- timeout 60 docker run --rm -v "$PWD:/workspace" -w /workspace ralph-loop-dev python -B -m pytest tests/ -v
- result: 74 passed in 2.44s