### PR TITLE
feat: add setup/teardown commands and Docker host networking for visual verification

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -241,6 +241,8 @@ class VisualVerifyConfig(BaseModel):
     assertion: str                         # Natural language: what to check
     viewport_width: int = 1280
     viewport_height: int = 720
+    setup_commands: list[str] = Field(default_factory=list)    # Commands to run on HOST before screenshot
+    teardown_commands: list[str] = Field(default_factory=list) # Commands to run on HOST after screenshot
 
 class RalphConfig(BaseModel):
     """Root configuration loaded from a global config file."""
@@ -823,6 +825,22 @@ The bash script and containers communicate via files in `.ralph-tmp/` (inside th
   "command": "verify",
   "task_id": "01",
   "commands": ["./bin/run-tests tests/path/to/test.py"]
+}
+
+// command: "visual"
+{
+  "command": "visual",
+  "task_id": "01",
+  "image": "ralph-loop-copilot",
+  "model": "claude-opus-4-6",
+  "timeout_seconds": 300,
+  "extra_flags": [],
+  "setup_commands": ["docker compose up -d myservice", "sleep 3"],
+  "teardown_commands": ["docker compose stop myservice"],
+  "auth": {
+    "env": [],
+    "mount": ["~/.config/gh"]
+  }
 }
 
 // command: "inspect"  
@@ -1532,7 +1550,7 @@ On retry, ALL accumulated feedback is injected into the coder prompt so the AI s
 ## Verification Pipeline
 
 1. **Deterministic** (`verify_commands`): run ALL commands on HOST, collect all stdout/stderr/exit_codes. Do NOT stop on first failure.
-2. **Visual** (optional, `visual_verify`): take screenshot via Playwright/MCP and validate with AI backend (with or without reference image).
+2. **Visual** (optional, `visual_verify`): run `setup_commands` on HOST (e.g., start services), take screenshot via Playwright inside container (with `--add-host=host.docker.internal:host-gateway` and automatic `localhost` → `host.docker.internal` URL rewriting), validate with AI backend (with or without reference image), then run `teardown_commands` on HOST.
 3. **AI Inspection** (always): capture `git diff`, build inspection prompt with diff + acceptance criteria + contract + previous feedback, execute via inspector backend, parse pass/fail verdict.
 4. **Aggregate**: all pass → PASS; any fail → FAIL with accumulated feedback entries.
 

--- a/examples/multi-phase-visual/PROGRESS.yaml
+++ b/examples/multi-phase-visual/PROGRESS.yaml
@@ -47,4 +47,6 @@ phases:
           assertion: homepage layout matches reference
           viewport_width: 1280
           viewport_height: 720
+          setup_commands: []
+          teardown_commands: []
         feedback: []

--- a/ralph-loop
+++ b/ralph-loop
@@ -111,6 +111,59 @@ run_cli() {
     docker run --rm -u "$DOCKER_USER" -v "$PWD:/workspace" "${auth_env[@]}" "${auth_mount[@]}" "$image" "$@"
 }
 
+run_visual_cli() {
+    local image="$1"; shift
+    local auth_env=() auth_mount=()
+    local container_home="/home/ralph"
+
+    while IFS= read -r env_var; do
+        [[ -n "${!env_var:-}" ]] && auth_env+=("-e" "$env_var")
+    done < <(jq -r '.auth.env[]? // empty' "$RALPH_TMP/next-action.json")
+
+    while IFS= read -r mount_path; do
+        expanded="${mount_path/#\~/$HOME}"
+        if [[ -d "$expanded" ]]; then
+            if [[ "$mount_path" == "~/"* ]]; then
+                container_target="${container_home}/${mount_path:2}"
+            else
+                container_target="$expanded"
+            fi
+            auth_mount+=("-v" "${expanded}:${container_target}")
+        fi
+    done < <(jq -r '.auth.mount[]? // empty' "$RALPH_TMP/next-action.json")
+
+    docker run --rm -u "$DOCKER_USER" \
+        --add-host=host.docker.internal:host-gateway \
+        -v "$PWD:/workspace" \
+        "${auth_env[@]}" "${auth_mount[@]}" "$image" "$@"
+}
+
+run_visual_setup_commands() {
+    local cwd="$1"
+    while IFS= read -r cmd; do
+        [[ -z "$cmd" ]] && continue
+        log_info "Task $TASK_ID: visual setup -> $cmd"
+        set +e
+        run_trusted_verify_cmd "$cwd" "$cmd"
+        local cmd_exit=$?
+        set -e
+        if [[ "$cmd_exit" -ne 0 ]]; then
+            log_warn "Task $TASK_ID: visual setup command exited with $cmd_exit"
+        fi
+    done < <(jq -r '.setup_commands[]? // empty' "$RALPH_TMP/next-action.json")
+}
+
+run_visual_teardown_commands() {
+    local cwd="$1"
+    while IFS= read -r cmd; do
+        [[ -z "$cmd" ]] && continue
+        log_info "Task $TASK_ID: visual teardown -> $cmd"
+        set +e
+        run_trusted_verify_cmd "$cwd" "$cmd"
+        set -e
+    done < <(jq -r '.teardown_commands[]? // empty' "$RALPH_TMP/next-action.json")
+}
+
 run_cli_with_auth_file() {
     local image="$1"; shift
     local auth_file="$1"; shift
@@ -381,13 +434,16 @@ cmd_run() {
             visual)
                 IMAGE=$(jq -r '.image' "$RALPH_TMP/next-action.json")
                 build_backend_args
+                VERIFY_CWD_RAW=$(jq -r '.workspace_dir // "/workspace"' "$RALPH_TMP/next-action.json")
+                VERIFY_CWD=$(container_path_to_host_path "$VERIFY_CWD_RAW")
                 log_info "Task $TASK_ID: visual check via $IMAGE..."
+                run_visual_setup_commands "$VERIFY_CWD"
                 VISUAL_STDOUT_FILE="$RALPH_TMP/visual-stdout.txt"
                 VISUAL_STDERR_FILE="$RALPH_TMP/visual-stderr.txt"
                 : > "$VISUAL_STDOUT_FILE"
                 : > "$VISUAL_STDERR_FILE"
                 set +e
-                run_cli "$IMAGE" visual \
+                run_visual_cli "$IMAGE" visual \
                     --config "/workspace/$CONFIG" \
                     --loop-dir "/workspace/$LOOP_DIR" \
                     --task-id "$TASK_ID" \
@@ -396,6 +452,7 @@ cmd_run() {
                     2> >(tee "$VISUAL_STDERR_FILE" >&2)
                 EXIT_CODE=$?
                 set -e
+                run_visual_teardown_commands "$VERIFY_CWD"
                 STDOUT=$(cat "$VISUAL_STDOUT_FILE")
                 log_info "Task $TASK_ID: visual finished (exit $EXIT_CODE)"
                 jq -n --arg task "$TASK_ID" --argjson exit "$EXIT_CODE" --arg out "$STDOUT" '{step:"visual",task_id:$task,exit_code:$exit,stdout:$out}' > "$RALPH_TMP/step-result.json"

--- a/ralph_loop/cli.py
+++ b/ralph_loop/cli.py
@@ -1091,6 +1091,9 @@ def next_action_command(config_path: str, loop_dir: str, step_result_path: str |
                             "model": visual.model,
                             "timeout_seconds": visual.timeout_seconds,
                             "extra_flags": visual.extra_flags,
+                            "setup_commands": task.visual_verify.setup_commands,
+                            "teardown_commands": task.visual_verify.teardown_commands,
+                            "workspace_dir": config.workspace_dir,
                             "auth": config.get_auth(visual.engine).model_dump(),
                         }
                     )
@@ -1133,6 +1136,9 @@ def next_action_command(config_path: str, loop_dir: str, step_result_path: str |
                             "model": visual.model,
                             "timeout_seconds": visual.timeout_seconds,
                             "extra_flags": visual.extra_flags,
+                            "setup_commands": task.visual_verify.setup_commands,
+                            "teardown_commands": task.visual_verify.teardown_commands,
+                            "workspace_dir": config.workspace_dir,
                             "auth": config.get_auth(visual.engine).model_dump(),
                         }
                     )

--- a/ralph_loop/config.py
+++ b/ralph_loop/config.py
@@ -124,6 +124,8 @@ class VisualVerifyConfig(BaseModel):
     assertion: str
     viewport_width: int = 1280
     viewport_height: int = 720
+    setup_commands: list[str] = Field(default_factory=list)
+    teardown_commands: list[str] = Field(default_factory=list)
 
 
 class RalphConfig(BaseModel):

--- a/ralph_loop/prompts/plan_to_tasks.md.j2
+++ b/ralph_loop/prompts/plan_to_tasks.md.j2
@@ -24,7 +24,9 @@ Schema:
             "reference": "string|null",
             "assertion": "string",
             "viewport_width": 1280,
-            "viewport_height": 720
+            "viewport_height": 720,
+            "setup_commands": ["string"],
+            "teardown_commands": ["string"]
           } | null,
           "files_to_touch": ["string"],
           "files_not_to_touch": ["string"],
@@ -44,6 +46,8 @@ Rules:
 - Do not prefix `verify_commands` with `cd tmp/product` (or any `cd` to the workspace path).
 - Include `visual_verify` for tasks that explicitly require visual checks.
 - If visual verification should inspect only the current screenshot, set `visual_verify.reference` to `null`.
+- When `visual_verify.url` targets a local service (e.g., `http://localhost:PORT`), populate `setup_commands` with the commands needed to start that service (e.g., `docker compose up -d SERVICE`, `sleep 3`) and `teardown_commands` to stop it. These run on the host before and after the screenshot.
+- If the service is already guaranteed to be running externally, leave `setup_commands` and `teardown_commands` as empty arrays.
 - If additional directives conflict with inferred hints, additional directives take precedence.
 - Output valid JSON with double quotes only.
 

--- a/ralph_loop/verification/visual.py
+++ b/ralph_loop/verification/visual.py
@@ -146,7 +146,10 @@ def _capture_screenshot(config: VisualVerifyConfig, workspace: Path) -> _Screens
 def _normalize_visual_target_url(raw_url: str, workspace: Path) -> str:
     parsed = urlparse(raw_url)
     if parsed.scheme in {"http", "https", "data"}:
-        return raw_url
+        url = raw_url
+        if _is_running_in_container():
+            url = _rewrite_localhost_for_container(url)
+        return url
 
     if parsed.scheme == "file":
         path_value = _extract_file_url_path(parsed)
@@ -156,6 +159,25 @@ def _normalize_visual_target_url(raw_url: str, workspace: Path) -> str:
         return raw_url
 
     return _resolve_local_path(raw_url, workspace).as_uri()
+
+
+def _is_running_in_container() -> bool:
+    """Detect if we are running inside a Docker container."""
+    return Path("/.dockerenv").exists() or (
+        Path("/proc/1/cgroup").exists()
+        and "docker" in Path("/proc/1/cgroup").read_text(errors="ignore")
+    )
+
+
+def _rewrite_localhost_for_container(url: str) -> str:
+    """Rewrite localhost URLs to host.docker.internal for container→host access."""
+    import re
+
+    return re.sub(
+        r"(https?://)localhost(:\d+)?",
+        r"\1host.docker.internal\2",
+        url,
+    )
 
 
 def _extract_file_url_path(parsed: object) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1147,6 +1147,68 @@ def test_next_action_includes_visual_step(sample_workspace: Path, monkeypatch) -
     assert json.loads(third.output)["command"] == "inspect"
 
 
+def test_next_action_visual_includes_setup_teardown_commands(
+    sample_workspace: Path, monkeypatch
+) -> None:
+    config_path = sample_workspace / "ralph-config.yaml"
+    progress_path = sample_workspace / "PROGRESS.yaml"
+    tmp_dir = sample_workspace / ".ralph-tmp"
+    tmp_dir.mkdir(exist_ok=True)
+
+    progress = load_progress(str(progress_path))
+    progress.phases[0].tasks[0].verify_commands = []
+    progress.phases[0].tasks[0].visual_verify = VisualVerifyConfig.model_validate(
+        {
+            "type": "screenshot",
+            "url": "http://localhost:8894",
+            "reference": None,
+            "assertion": "Layout should match",
+            "viewport_width": 1280,
+            "viewport_height": 720,
+            "setup_commands": ["docker compose up -d myservice", "sleep 3"],
+            "teardown_commands": ["docker compose stop myservice"],
+        }
+    )
+    save_progress(progress, str(progress_path))
+
+    config = RalphConfig.load(str(config_path))
+    original_exists = Path.exists
+
+    def _patched_exists(path: Path) -> bool:
+        if path.resolve() == Path(config.pause_file).resolve():
+            return False
+        return original_exists(path)
+
+    monkeypatch.setattr("ralph_loop.cli.Path.exists", _patched_exists)
+
+    runner = CliRunner()
+    first = runner.invoke(main, ["next-action", "--config", str(config_path)])
+    assert first.exit_code == 0
+    assert json.loads(first.output)["command"] == "code"
+
+    step_result = tmp_dir / "step-result.json"
+    step_result.write_text(
+        json.dumps({"step": "code", "task_id": "01", "exit_code": 0}),
+        encoding="utf-8",
+    )
+    second = runner.invoke(
+        main,
+        [
+            "next-action",
+            "--config",
+            str(config_path),
+            "--step-result",
+            str(step_result),
+        ],
+    )
+    assert second.exit_code == 0
+    second_payload = json.loads(second.output)
+    assert second_payload["command"] == "visual"
+    assert second_payload["setup_commands"] == ["docker compose up -d myservice", "sleep 3"]
+    assert second_payload["teardown_commands"] == ["docker compose stop myservice"]
+    assert "workspace_dir" in second_payload
+
+
 def test_next_action_returns_abort_when_any_task_is_aborted(
     sample_workspace: Path, monkeypatch
 ) -> None:

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -325,3 +325,75 @@ demo
 
     assert result.verdict == "pass"
     assert "single screenshot ok" in result.details
+
+
+def test_visual_url_rewriting_in_container(monkeypatch, tmp_path) -> None:
+    """Test that localhost URLs are rewritten to host.docker.internal inside containers."""
+    from ralph_loop.verification.visual import (
+        _normalize_visual_target_url,
+        _rewrite_localhost_for_container,
+    )
+
+    # Direct rewrite function
+    assert (
+        _rewrite_localhost_for_container("http://localhost:8894")
+        == "http://host.docker.internal:8894"
+    )
+    assert (
+        _rewrite_localhost_for_container("http://localhost:3000/api")
+        == "http://host.docker.internal:3000/api"
+    )
+    assert _rewrite_localhost_for_container("http://example.com:8080") == "http://example.com:8080"
+
+    # Simulate container environment
+    dockerenv = tmp_path / ".dockerenv"
+    dockerenv.touch()
+    monkeypatch.setattr(
+        "ralph_loop.verification.visual._is_running_in_container",
+        lambda: True,
+    )
+
+    result = _normalize_visual_target_url("http://localhost:8894", tmp_path)
+    assert result == "http://host.docker.internal:8894"
+
+    # Non-localhost URLs are not rewritten
+    result = _normalize_visual_target_url("http://myservice:8080", tmp_path)
+    assert result == "http://myservice:8080"
+
+
+def test_visual_url_not_rewritten_outside_container(monkeypatch, tmp_path) -> None:
+    """Test that localhost URLs are NOT rewritten when not in a container."""
+    from ralph_loop.verification.visual import _normalize_visual_target_url
+
+    monkeypatch.setattr(
+        "ralph_loop.verification.visual._is_running_in_container",
+        lambda: False,
+    )
+
+    # Outside container, localhost stays as-is
+    result = _normalize_visual_target_url("http://localhost:8894", tmp_path)
+    assert result == "http://localhost:8894"
+
+
+def test_visual_verify_config_accepts_setup_teardown_commands() -> None:
+    """Test that VisualVerifyConfig accepts setup and teardown commands."""
+    config = VisualVerifyConfig(
+        type="screenshot",
+        url="http://localhost:8894",
+        assertion="Page loads correctly",
+        setup_commands=["docker compose up -d myservice", "sleep 3"],
+        teardown_commands=["docker compose stop myservice"],
+    )
+    assert config.setup_commands == ["docker compose up -d myservice", "sleep 3"]
+    assert config.teardown_commands == ["docker compose stop myservice"]
+
+
+def test_visual_verify_config_defaults_empty_setup_teardown() -> None:
+    """Test that setup and teardown commands default to empty lists."""
+    config = VisualVerifyConfig(
+        type="screenshot",
+        url="http://localhost:8894",
+        assertion="Page loads correctly",
+    )
+    assert config.setup_commands == []
+    assert config.teardown_commands == []


### PR DESCRIPTION
Closes #16

## Summary

Visual verification fails when:
1. The service under test is not running during screenshot capture
2. The container cannot reach `localhost` on the host (`net::ERR_CONNECTION_REFUSED`)

## Changes

- **`ralph_loop/config.py`** — Add `setup_commands` / `teardown_commands` fields to `VisualVerifyConfig`
- **`ralph-loop`** (bash) — New `run_visual_cli()` with `--add-host=host.docker.internal:host-gateway`, plus `run_visual_setup_commands()` / `run_visual_teardown_commands()` helpers
- **`ralph_loop/cli.py`** — Include setup/teardown/workspace_dir in visual next-action JSON payload
- **`ralph_loop/verification/visual.py`** — Container detection (`/.dockerenv`) + auto-rewrite `localhost` → `host.docker.internal`
- **`ralph_loop/prompts/plan_to_tasks.md.j2`** — Schema and rules for setup_commands when visual needs a running service
- **`docs/design.md`** — Spec updated with new fields and visual next-action schema
- **`examples/multi-phase-visual/PROGRESS.yaml`** — Example updated
- **`tests/`** — 5 new tests (79/79 passing, ruff + mypy clean)